### PR TITLE
clear neopixel bounce

### DIFF
--- a/py/boot.py
+++ b/py/boot.py
@@ -3,6 +3,8 @@
 
 import machine
 import pyb
+import quokka
+quokka.neopixels.show()
 #pyb.main('main.py') # main script to run after this one
 #pyb.usb_mode('VCP+MSC') # act as a serial and a storage device
 #pyb.usb_mode('VCP+HID') # act as a serial device and a mouse


### PR DESCRIPTION
Plugging in USB often causes neopixels to turn on, these lines in boot.py turn them off on soft reboot.