### PR TITLE
Make update script more general, work on OSX

### DIFF
--- a/py/update.sh
+++ b/py/update.sh
@@ -1,23 +1,34 @@
 #!/bin/bash
 
-# For setting up a new Quokka.
-# Copies all libraries and one of the demos onto the board as main.py.
+# Copies one of the demos to the quokka as main,py
 # e.g.   ./update.sh buttons-display-neopixels
 # After copying everything, it connects the serial console so you can Ctrl-C/Ctrl-D.
+
+# For setting up a new Quokka, pass the -u flag to the script.
+# This copies all libraries and one of the demos onto the board as main.py.
 
 # For ongoing development, rather than using this script, set up three terminals:
 # 1. screen /dev/ttyACM0 115200
 # 2. editor (e.g. main.py)
-# 3. prompt $ cp main.py /media/PYBFLASH && sync
+# 3. prompt $ cp {filename}.py /media/PYBFLASH/main.py && sync
 # Then for every update, run #3, then in #1:
 #   - Ctrl-C (to stop current program)
 #   - Ctrl-D (to force filesystem reload and start the new program)
 
-cp quokka.py /media/PYBFLASH/
-cp boot.py /media/PYBFLASH/
-mkdir -p /media/PYBFLASH/drivers
-cp drivers/*.py /media/PYBFLASH/drivers
-cp demos/${1}.py /media/PYBFLASH/main.py
+# If using an SD card with your quokka, update this volume name
+VOL_NAME="PYBFLASH"
+
+# If the -u flag is given, update the libraries
+# Otherwise, only the main files are updated
+if [ "$1" = "-u" ]; then
+    cp quokka.py /media/$VOL_NAME/
+    cp boot.py /media/$VOL_NAME/
+    mkdir -p /media/$VOL_NAME/drivers
+    cp drivers/*.py /media/$VOL_NAME/drivers/
+    shift
+fi
+# Copy the demo onto the board
+cp demos/${1}.py /media/$VOL_NAME/main.py
 sync
 
 screen /dev/ttyACM0 115200

--- a/py/update.sh
+++ b/py/update.sh
@@ -36,8 +36,14 @@ if [ "$1" = "-u" ]; then
     cp drivers/*.py /$VOL_DIR/$VOL_NAME/drivers/
     shift
 fi
-# Copy the demo onto the board
-cp demos/${1}.py /$VOL_DIR/$VOL_NAME/main.py
+
+# If there is no argument given, copy main.py, otherwise copy the named demo
+if [ $# -eq 0 ]; then
+    cp main.py /$VOL_DIR/$VOL_NAME/main.py
+else
+    # Copy the demo onto the board
+    cp demos/${1}.py /$VOL_DIR/$VOL_NAME/main.py
+fi
 sync
 
 if [ $OSX -eq 0 ]; then

--- a/py/update.sh
+++ b/py/update.sh
@@ -15,20 +15,33 @@
 #   - Ctrl-C (to stop current program)
 #   - Ctrl-D (to force filesystem reload and start the new program)
 
+# Check if we are on a mac
+if [ `uname` = "Darwin" ]; then
+    VOL_DIR="Volumes"
+    OSX=1
+else
+    VOL_DIR="media"
+    OSX=0
+fi
+
 # If using an SD card with your quokka, update this volume name
 VOL_NAME="PYBFLASH"
 
 # If the -u flag is given, update the libraries
 # Otherwise, only the main files are updated
 if [ "$1" = "-u" ]; then
-    cp quokka.py /media/$VOL_NAME/
-    cp boot.py /media/$VOL_NAME/
-    mkdir -p /media/$VOL_NAME/drivers
-    cp drivers/*.py /media/$VOL_NAME/drivers/
+    cp quokka.py /$VOL_DIR/$VOL_NAME/
+    cp boot.py /$VOL_DIR/$VOL_NAME/
+    mkdir -p /$VOL_DIR/$VOL_NAME/drivers
+    cp drivers/*.py /$VOL_DIR/$VOL_NAME/drivers/
     shift
 fi
 # Copy the demo onto the board
-cp demos/${1}.py /media/$VOL_NAME/main.py
+cp demos/${1}.py /$VOL_DIR/$VOL_NAME/main.py
 sync
 
-screen /dev/ttyACM0 115200
+if [ $OSX -eq 0 ]; then
+    screen /dev/ttyACM0 115200
+else
+    screen $(ls /dev/tty.usbmodem* | head -n1) 115200
+fi

--- a/py/update_mac.sh
+++ b/py/update_mac.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-cp quokka.py /Volumes/PYBFLASH/
-cp boot.py /Volumes/PYBFLASH/
-mkdir -p /Volumes/PYBFLASH/drivers
-cp drivers/*.py /Volumes/PYBFLASH/drivers
-cp demos/${1}.py /Volumes/PYBFLASH/main.py
-sync
-#screen /dev/tty.usbmodem1412 115200


### PR DESCRIPTION
Merges `update.sh` and `update_mac.sh` into one file. Detects the OS automatically and sets appropriate directories.

In addition, couple of new features added to the script:
 - Copy `main.py` from current directory if no directory argument given.
 - Only copies driver files when the `-u` flag is passed to the script as the first argument.
 - Allow changing the name of the directory to copy to, necessary when using an SD card.
 - Detect the name of the first USB serial port on OSX, as the numbering seems to be inconsistent between boards and computers.

@jimmo