### PR TITLE
Animation, Sprite game and Scroll_Text from Quokka Party

### DIFF
--- a/py/demos/animate.py
+++ b/py/demos/animate.py
@@ -1,0 +1,69 @@
+import quokka
+
+HEART = [
+0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+0,0,0,0,1,1,1,0,0,0,1,1,1,0,0,0,
+0,0,0,1,0,0,0,1,0,1,0,0,0,1,0,0,
+0,0,1,0,0,0,0,0,1,0,0,0,0,0,1,0,
+0,0,1,0,0,0,0,0,0,0,0,0,0,0,1,0,
+0,0,1,0,0,0,0,0,0,0,0,0,0,0,1,0,
+0,0,0,1,0,0,0,0,0,0,0,0,0,1,0,0,
+0,0,0,0,1,0,0,0,0,0,0,0,1,0,0,0,
+0,0,0,0,0,1,0,0,0,0,0,1,0,0,0,0,
+0,0,0,0,0,0,1,0,0,0,1,0,0,0,0,0,
+0,0,0,0,0,0,0,1,0,1,0,0,0,0,0,0,
+0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
+
+DIAMOND = [
+0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,
+0,0,0,0,0,0,0,1,0,1,0,0,0,0,0,0,
+0,0,0,0,0,0,1,0,0,0,1,0,0,0,0,0,
+0,0,0,0,0,1,0,0,0,0,0,1,0,0,0,0,
+0,0,0,0,1,0,0,0,0,0,0,0,1,0,0,0,
+0,0,0,1,0,0,0,0,0,0,0,0,0,1,0,0,
+0,0,1,0,0,0,0,0,0,0,0,0,0,0,1,0,
+0,0,1,0,0,0,0,0,0,0,0,0,0,0,1,0,
+0,0,0,1,0,0,0,0,0,0,0,0,0,1,0,0,
+0,0,0,0,1,0,0,0,0,0,0,0,1,0,0,0,
+0,0,0,0,0,1,0,0,0,0,0,1,0,0,0,0,
+0,0,0,0,0,0,1,0,0,0,1,0,0,0,0,0,
+0,0,0,0,0,0,0,1,0,1,0,0,0,0,0,0,
+0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
+
+
+def show_pic(fb, img=DIAMOND, colour = 1, start_x = 0, start_y = 0,  scale = 4, repeat = False ):
+    #what happens to validate my inputs, what happens if start x and y are wrong, scale is too high etc?
+    #need to deal with screen width and height to ensure I'm not writing to empty indexes.
+    for i,cell in enumerate(img):
+        #find the row
+        x=i%16
+        y=i//16
+        #scale and update the fb
+        if cell: 
+            #test for being on screen
+            fb.fill_rect(scale * x + start_x, scale*y + start_y, scale, scale, colour)
+def animate(fb, fps = 5, img = HEART, colour = 1, start_x = 0, start_y = 0, scale = 4, repeat = False ):
+    fb.fill((colour+1)%2)
+    show_pic(fb, img = img, colour = colour, start_x = start_x, start_y = start_y, scale = scale, repeat = repeat)
+    fb.show()
+    quokka.sleep(1000//fps)
+    fb.fill((colour+1)%2)
+    show_pic(fb, img = img, colour = colour, 
+        start_x = start_x + scale**2, start_y = start_y + scale**2, scale = scale//2, repeat = repeat)
+    fb.show()
+    quokka.sleep(1000//fps)
+
+if __name__ == '__main__':
+    fb = quokka.display
+    while True:
+        animate(fb)
+        
+    
+
+

--- a/py/demos/game_with_sprites.py
+++ b/py/demos/game_with_sprites.py
@@ -1,0 +1,104 @@
+import quokka, framebuf, random, pyb
+SMILEY = """
+111110000011111
+111001111100111
+110111111111011
+101111111111101
+101111111111101
+011001111100110
+011001111100110
+011111111111110
+011111111111110
+011011111110110
+101101111101101
+101110000011101
+110111000111011
+111001111100111
+111110000011111
+"""
+BADDIE = """
+000111111111000
+100011111110001
+110001111100011
+111000111000111
+111100010001111
+111110000011111
+111111000111111
+111110000011111
+111100010001111
+111000111000111
+110001111100011
+100011111110001
+000111111111000
+"""
+WIDTH = 128
+HEIGHT = 64
+
+move_x = False
+def move(timer):
+    global move_x
+    move_x = True
+
+def draw_sprite(sprite):
+    piclist = sprite.split()
+    width = len(piclist[0])
+    height = len(piclist)
+    buf = bytearray(width*height)
+    fb = framebuf.FrameBuffer(buf, width, height, framebuf.MONO_VLSB)
+    #FrameBuffer.pixel(x, y[, c])
+    y=0
+    for line in piclist:
+        x=0
+        for char in line:
+            fb.pixel(x,y,int(char))
+            x+=1
+        y+=1
+    return fb,width,height
+hero, hero_width, hero_height = draw_sprite(SMILEY)
+baddie, baddie_width, baddie_height = draw_sprite(BADDIE)
+
+hero_x = hero_width//2
+hero_y = hero_height//2
+
+baddie_x = random.randint(0,(WIDTH-baddie_width))
+baddie_y = random.randint(0,(HEIGHT-baddie_height))
+
+timer = pyb.Timer(4)
+timer.init(freq=0.25)
+timer.callback(move)
+
+quokka.display.fill(1)
+quokka.display.blit(hero,hero_x,hero_y)
+quokka.display.blit(baddie,baddie_x,baddie_y)
+quokka.display.show()
+
+score = 0
+def collide():
+    return baddie_x <= hero_x <= baddie_x+baddie_width and baddie_y <= hero_y <= baddie_y+baddie_height or \
+            baddie_x <= hero_x+hero_width <= baddie_x+baddie_width and baddie_y <= hero_y+hero_height <= baddie_y+baddie_height
+while True:
+    if move_x:
+        baddie_x = random.randint(0,(WIDTH-baddie_width))
+        baddie_y = random.randint(0,(HEIGHT-baddie_height))
+        move_x=False
+    if quokka.buttons.a.was_pressed(): #A button
+        hero_x -= hero_width//2
+    if quokka.buttons.b.was_pressed(): #B button
+        hero_x += hero_width//2
+    if quokka.buttons.c.was_pressed(): #C button
+        hero_y -= hero_height//2
+    if quokka.buttons.d.was_pressed(): #D button
+        hero_y += hero_height//2
+    #collision detect
+    #if x of good is between x_bad and x_bad + width or x + width is between x bad and x bad + width
+    if collide():
+        #collision
+        score+=1
+        move_x=True
+        timer.init(freq=0.25)
+        print(score)
+    
+    quokka.display.fill(1)
+    quokka.display.blit(hero,hero_x,hero_y)
+    quokka.display.blit(baddie,baddie_x,baddie_y)
+    quokka.display.show()

--- a/py/demos/scroll_text.py
+++ b/py/demos/scroll_text.py
@@ -1,0 +1,23 @@
+# main.py -- put your code here!
+import quokka
+
+def scroll(string, stringScale=2,
+         charWidth=8,scWidth=128,
+         charHeight=8,scHeight=64,
+         startx = 5, starty = 5,
+         textColour = 1):
+    numchars=(scWidth-startx)//(charWidth*stringScale)
+    
+    while string:
+        quokka.display.fill(1-textColour)
+        quokka.display.text(string[:numchars], startx, starty, textColour, scale=stringScale)
+        quokka.display.show()
+        if len(string)>1:
+            string = string[1:]
+        else:
+            string = ""
+        quokka.sleep(200)
+    quokka.display.fill(1-textColour)
+            
+    
+scroll('Twas Brilig and the slivey toves did gyre and gimble in the wabe.')


### PR DESCRIPTION
Stuff we made for the quokka party today. Animate is old but it reads in a string as an image and flashes two different sizes. 

Sprite game involves similarly pulling in a string as a sprite and moving it around the screen - the collision detection is lousy and I didn't get to update a score. The Sprite needs to be a class with all of this functionality encapsulated to better mimic pygame.

Scroll_text scrolls text with any scale. After making this we realised you could scroll unscaled t3ext really easily but the scaling function only stores a 128 X 64 pixel framebuffer so it truncates the text and scroll won't work properly. I think that fixing the scroll is probably the better way to go but thought the demo might be useful.